### PR TITLE
Added logging capabilities, and a bit more

### DIFF
--- a/clearmf_list.sh
+++ b/clearmf_list.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # use clearmf.sh PASS USER
-# Not to run in parallel, remove the "&" the end of lines
+# Runs all IPs in parallel, remove "&" the end of `sshpath` lines to disable
 
 # In DNS server
 # List with
@@ -16,12 +16,18 @@ _input=/opt/remove_ubnt_mf/iplist.txt
 pass=$1
 user=$2
 
+# Create log
+log_dir=clearmf_list
+mkdir $log_dir
+
 for ip in `grep -v ^# $_input | awk '{print $1}'`; do
         echo "Checking $ip..."
+        echo "$ip" > $log_dir/$ip.log
+
         #Only remove
-        sshpass -p $pass ssh  -o ConnectTimeout=10 -o StrictHostKeyChecking=no $user@$ip "trigger_url  https://raw.githubusercontent.com/diegocanton/remove_ubnt_mf/master/desinfect.sh | sh" &
-        
+        sshpass -p $pass ssh  -o ConnectTimeout=10 -o StrictHostKeyChecking=no $user@$ip "trigger_url  https://raw.githubusercontent.com/diegocanton/remove_ubnt_mf/master/desinfect.sh | sh" >> $log_dir/$ip.log 2>&1 &
+
         #Only upgrade
-        #sshpass -p $pass ssh  -o ConnectTimeout=10 -o StrictHostKeyChecking=no $user@$ip "trigger_url  https://raw.githubusercontent.com/diegocanton/remove_ubnt_mf/master/upgrade.sh | sh" &
+        #sshpass -p $pass ssh  -o ConnectTimeout=10 -o StrictHostKeyChecking=no $user@$ip "trigger_url  https://raw.githubusercontent.com/diegocanton/remove_ubnt_mf/master/upgrade.sh | sh" >> $log_dir/$ip.log 2>&1 &
 
 done

--- a/consolidate_logs.sh
+++ b/consolidate_logs.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Scans for log directories and creates a single log file
+#
+# When cleanmf.sh is ran, a log directory is created
+# with a log files for every IP address.
+# This script consolidates each IP log into 1 file.
+
+for d in */ ; do
+  d2=${d::-1}
+  awk 'FNR==1{print ""}1' $d*.log > $d2.log
+done

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -7,13 +7,13 @@ FILE=/bin/ubntbox
 # Check if device is Ubiquiti Radio
 if [ -e "$FILE" ] ; then
     echo "Enable compilance test..."
-    
+
     # Ativa Compilance Test
     touch /etc/persistent/ ct
     /bin/cfgmtd -w -p /etc/
 
     echo "Upgrade firmware"
-    
+
     #detect version of fw - Colaboration PVi1 (Git user)
     versao=`mca-status  | grep firmware | cut -d, -f3 | cut -d= -f2 | cut -d. -f1`
     if [ "$versao" == "XM" ]; then
@@ -22,12 +22,13 @@ if [ -e "$FILE" ] ; then
         URL='http://dl.ubnt.com/firmwares/XN-fw/v5.6.5/XM.v5.6.5.29033.160515.2119.bin'
         wget $URL -O /tmp/firmware.bin
         ubntbox fwupdate.real -m /tmp/firmware.bin
-    fi
-    if [ "$versao" == "XW" ]; then
+    elif [ "$versao" == "XW" ]; then
         echo "Device XW"
         #URL='http://dl.ubnt.com/firmwares/XW-fw/v5.6.4/XW.v5.6.4.28924.160331.1238.bin'
         URL='http://dl.ubnt.com/firmwares/XW-fw/v5.6.5/XW.v5.6.5.29033.160515.2108.bin'
         wget $URL -O /tmp/firmware.bin
         ubntbox fwupdate.real -m /tmp/firmware.bin
+    else
+        echo "Device Unknown"
     fi
 fi


### PR DESCRIPTION
- clearmf.sh accepts a last IP, default is 254
- clearmf.sh and clearmf_list.sh will now log the output of each ssh connection into a directory that is created based on the network and IP range
- each log includes both standard output and error output
- changed sshpath command from desinfect to disinfect
- consolidate_logs.sh scans for log directories and creates a single log file for each
- upgrade.sh will return "Device unknown" if it doesn't match XM or XW
